### PR TITLE
Show current team with selection screen

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -26,7 +26,8 @@
             android:label="@string/title_activity_settings" />
         <activity
             android:name=".ui.teams.TeamSelectionActivity"
-            android:exported="false" />
+            android:exported="false"
+            android:theme="@style/Theme.Kolco24.NoActionBar" />
         <activity
             android:name=".ui.photo.NewPhotoActivity"
             android:exported="false"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -25,6 +25,9 @@
             android:exported="false"
             android:label="@string/title_activity_settings" />
         <activity
+            android:name=".ui.teams.TeamSelectionActivity"
+            android:exported="false" />
+        <activity
             android:name=".ui.photo.NewPhotoActivity"
             android:exported="false"
             android:label="Добавить фото КП"

--- a/app/src/main/java/ru/kolco24/kolco24/ui/teams/TeamSelectionActivity.kt
+++ b/app/src/main/java/ru/kolco24/kolco24/ui/teams/TeamSelectionActivity.kt
@@ -1,0 +1,76 @@
+package ru.kolco24.kolco24.ui.teams
+
+import android.os.Bundle
+import android.view.View
+import android.widget.Toast
+import androidx.appcompat.app.AppCompatActivity
+import androidx.lifecycle.ViewModelProvider
+import androidx.recyclerview.widget.LinearLayoutManager
+import ru.kolco24.kolco24.DataDownloader
+import ru.kolco24.kolco24.R
+import ru.kolco24.kolco24.databinding.ActivityTeamSelectionBinding
+
+class TeamSelectionActivity : AppCompatActivity() {
+    private lateinit var binding: ActivityTeamSelectionBinding
+    private lateinit var teamViewModel: TeamViewModel
+
+    private var categoryCode: Int = 0
+    private var categoryName: String = ""
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        binding = ActivityTeamSelectionBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+
+        categoryCode = intent.getIntExtra(EXTRA_CATEGORY_CODE, 0)
+        categoryName = intent.getStringExtra(EXTRA_CATEGORY_NAME).orEmpty()
+
+        setSupportActionBar(binding.toolbar)
+        supportActionBar?.setDisplayHomeAsUpEnabled(true)
+        supportActionBar?.title = if (categoryName.isNotBlank()) {
+            getString(R.string.select_team_title, categoryName)
+        } else {
+            getString(R.string.select_team_title_generic)
+        }
+        binding.toolbar.setNavigationOnClickListener { onBackPressedDispatcher.onBackPressed() }
+
+        val adapter = TeamListAdapter(TeamListAdapter.TeamDiff())
+        binding.recyclerTeams.layoutManager = LinearLayoutManager(this)
+        binding.recyclerTeams.adapter = adapter
+
+        teamViewModel = ViewModelProvider(this)[TeamViewModel::class.java]
+
+        teamViewModel.getTeamsByCategory(categoryCode).observe(this) { teams ->
+            adapter.submitList(teams)
+            if (teams.isNullOrEmpty()) {
+                binding.textNoTeams.visibility = View.VISIBLE
+            } else {
+                binding.textNoTeams.visibility = View.GONE
+            }
+            binding.swipeToRefresh.isRefreshing = false
+        }
+
+        teamViewModel.toastMessage.observe(this) { message ->
+            if (!message.isNullOrEmpty()) {
+                Toast.makeText(this, message, Toast.LENGTH_SHORT).show()
+                teamViewModel.clearToastMessage()
+            }
+        }
+
+        teamViewModel.isLoading().observe(this) { isLoading ->
+            binding.swipeToRefresh.isRefreshing = isLoading == true
+        }
+
+        binding.swipeToRefresh.setOnRefreshListener {
+            val dataDownloader = DataDownloader(application) {
+                binding.swipeToRefresh.isRefreshing = false
+            }
+            dataDownloader.downloadTeams(categoryCode)
+        }
+    }
+
+    companion object {
+        const val EXTRA_CATEGORY_CODE = "extra_category_code"
+        const val EXTRA_CATEGORY_NAME = "extra_category_name"
+    }
+}

--- a/app/src/main/java/ru/kolco24/kolco24/ui/teams/TeamViewHolder.java
+++ b/app/src/main/java/ru/kolco24/kolco24/ui/teams/TeamViewHolder.java
@@ -1,7 +1,9 @@
 package ru.kolco24.kolco24.ui.teams;
 
+import android.app.Activity;
 import android.app.AlertDialog;
 import android.content.Context;
+import android.content.ContextWrapper;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -58,6 +60,10 @@ public class TeamViewHolder extends RecyclerView.ViewHolder {
                                 "Команда \"" + team.getTeamname() + "\" выбрана как ваша",
                                 Toast.LENGTH_SHORT
                         ).show();
+                        Activity activity = unwrapActivity(itemView.getContext());
+                        if (activity instanceof TeamSelectionActivity) {
+                            activity.finish();
+                        }
                     })
                     .setNegativeButton("Нет", (dialogInterface, i) -> {
                     })
@@ -72,5 +78,15 @@ public class TeamViewHolder extends RecyclerView.ViewHolder {
         View view = LayoutInflater.from(parent.getContext())
                 .inflate(R.layout.team_item, parent, false);
         return new TeamViewHolder(view);
+    }
+
+    private static Activity unwrapActivity(Context context) {
+        while (context instanceof ContextWrapper) {
+            if (context instanceof Activity) {
+                return (Activity) context;
+            }
+            context = ((ContextWrapper) context).getBaseContext();
+        }
+        return null;
     }
 }

--- a/app/src/main/java/ru/kolco24/kolco24/ui/teams/TeamViewModel.java
+++ b/app/src/main/java/ru/kolco24/kolco24/ui/teams/TeamViewModel.java
@@ -35,6 +35,10 @@ public class TeamViewModel extends AndroidViewModel {
         return mRepository.getTeamsByCategory(category);
     }
 
+    LiveData<Team> getTeam(int id) {
+        return mRepository.getTeam(id);
+    }
+
     public Team getTeamById(int id) {
         return mRepository.getTeamById(id);
     }

--- a/app/src/main/java/ru/kolco24/kolco24/ui/teams/TeamsCategoryFragment.kt
+++ b/app/src/main/java/ru/kolco24/kolco24/ui/teams/TeamsCategoryFragment.kt
@@ -1,119 +1,139 @@
 package ru.kolco24.kolco24.ui.teams
 
+import android.content.Context
+import android.content.Intent
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
+import androidx.lifecycle.LiveData
 import androidx.lifecycle.ViewModelProvider
-import androidx.recyclerview.widget.LinearLayoutManager
-import ru.kolco24.kolco24.DataDownloader
+import ru.kolco24.kolco24.R
 import ru.kolco24.kolco24.data.entities.Team
 import ru.kolco24.kolco24.databinding.FragmentTeamsCategoryBinding
-import ru.kolco24.kolco24.ui.teams.TeamListAdapter.TeamDiff
 
-/**
- * A simple [Fragment] subclass.
- * Use the [TeamsCategoryFragment.newInstance] factory method to
- * create an instance of this fragment.
- */
 class TeamsCategoryFragment : Fragment() {
     private var binding: FragmentTeamsCategoryBinding? = null
-    private var teamViewModel: TeamViewModel? = null
+    private lateinit var teamViewModel: TeamViewModel
+    private var currentTeamLiveData: LiveData<Team?>? = null
 
-    // TODO: Rename and change types of parameters
-    private var categoryName: String? = null
-    private var categoryCode: Int? = null
+    private var categoryName: String = ""
+    private var categoryCode: Int = 0
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        if (arguments != null) {
-            categoryName = requireArguments().getString(CATEGORY_NAME)
-            categoryCode = requireArguments().getInt(CATEGORY_CODE)
+        arguments?.let { args ->
+            categoryName = args.getString(CATEGORY_NAME).orEmpty()
+            categoryCode = args.getInt(CATEGORY_CODE)
         }
     }
 
     override fun onCreateView(
-        inflater: LayoutInflater, container: ViewGroup?,
-        savedInstanceState: Bundle?
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
     ): View {
-        // Inflate the layout for this fragment
         binding = FragmentTeamsCategoryBinding.inflate(inflater, container, false)
-        val root: View = binding!!.root
-        // recycler view
-        val recyclerTeams = binding!!.recyclerTeams
-        val adapter = TeamListAdapter(TeamDiff())
-        recyclerTeams.adapter = adapter
-        recyclerTeams.layoutManager = LinearLayoutManager(context)
+        teamViewModel = ViewModelProvider(this)[TeamViewModel::class.java]
 
-        teamViewModel = ViewModelProvider(this).get(TeamViewModel::class.java)
-        teamViewModel!!.getTeamsByCategory(categoryCode).observe(
-            viewLifecycleOwner
-        ) { list: List<Team?> -> adapter.submitList(list) }
-        teamViewModel!!.getTeamsByCategory(categoryCode).observe(
-            viewLifecycleOwner
-        ) { teams: List<Team?> ->
-            if (teams.size == 0) {
-                binding!!.textNoTeams.visibility = View.VISIBLE
-                //                teamViewModel.downloadTeams("https://kolco24.ru/api/v1/teams");
+        binding?.apply {
+            textCategoryTitle.text = if (categoryName.isNotBlank()) {
+                getString(R.string.team_category_title_format, categoryName)
             } else {
-                binding!!.textNoTeams.visibility = View.GONE
-                binding!!.swipeToRefresh.isRefreshing = false
+                getString(R.string.select_team_title_generic)
+            }
+            buttonChangeTeam.setOnClickListener {
+                val intent = Intent(requireContext(), TeamSelectionActivity::class.java).apply {
+                    putExtra(TeamSelectionActivity.EXTRA_CATEGORY_CODE, categoryCode)
+                    putExtra(TeamSelectionActivity.EXTRA_CATEGORY_NAME, categoryName)
+                }
+                startActivity(intent)
             }
         }
-        binding!!.swipeToRefresh.setOnRefreshListener {
-            val dataDownloader = DataDownloader(
-                requireActivity().application
-            ) { binding!!.swipeToRefresh.isRefreshing = false }
-            dataDownloader.downloadTeams(categoryCode)
-        }
-        return root
-    }
 
-    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        super.onViewCreated(view, savedInstanceState)
-        //        TextView textView = view.findViewById(R.id.text);
-//        textView.setText(mParam1);
-        //toast observer
-        teamViewModel!!.toastMessage.observe(
-            viewLifecycleOwner
-        ) { s: String? ->
-            println("toast message: $s")
-            if (s != null) {
-                Toast.makeText(context, s, Toast.LENGTH_SHORT).show()
-                teamViewModel!!.clearToastMessage()
-            }
-        }
-        teamViewModel!!.isLoading().observe(
-            viewLifecycleOwner
-        ) { aBoolean: Boolean? ->
-            binding!!.swipeToRefresh.isRefreshing = aBoolean!!
-        }
-        //
+        updateCurrentTeam()
+
+        return binding!!.root
     }
 
     override fun onResume() {
         super.onResume()
-        (activity as AppCompatActivity).supportActionBar!!.title = "Команды $categoryName"
+        updateCurrentTeam()
+        (activity as? AppCompatActivity)?.supportActionBar?.title =
+            if (categoryName.isNotBlank()) {
+                getString(R.string.team_category_title_format, categoryName)
+            } else {
+                getString(R.string.select_team_title_generic)
+            }
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        currentTeamLiveData?.removeObservers(viewLifecycleOwner)
+        binding = null
+    }
+
+    private fun updateCurrentTeam() {
+        if (!isAdded) {
+            return
+        }
+        val sharedPreferences = requireContext().getSharedPreferences("team", Context.MODE_PRIVATE)
+        val teamId = sharedPreferences.getInt("team_id", 0)
+        currentTeamLiveData?.removeObservers(viewLifecycleOwner)
+
+        if (teamId == 0) {
+            showNoTeam(getString(R.string.team_not_selected_message))
+            return
+        }
+
+        currentTeamLiveData = teamViewModel.getTeam(teamId)
+        currentTeamLiveData?.observe(viewLifecycleOwner) { team ->
+            if (team == null) {
+                showNoTeam(getString(R.string.team_not_found_message))
+                return@observe
+            }
+            if (team.category != categoryCode) {
+                showNoTeam(getString(R.string.team_category_mismatch_message))
+                return@observe
+            }
+            showTeam(team)
+        }
+    }
+
+    private fun showTeam(team: Team) {
+        binding?.apply {
+            containerTeamInfo.visibility = View.VISIBLE
+            textNoTeam.visibility = View.GONE
+            textTeamName.text = team.teamname
+            textTeamNumber.text = getString(R.string.team_number_format, team.startNumber)
+            textTeamCategory.text =
+                getString(R.string.team_category_format, categoryName.ifBlank { team.dist })
+            textTeamCity.text = getString(
+                R.string.team_city_format,
+                team.city.ifBlank { getString(R.string.team_info_not_specified) },
+            )
+            textTeamOrganization.text = getString(
+                R.string.team_organization_format,
+                team.organization.ifBlank { getString(R.string.team_info_not_specified) },
+            )
+            textTeamMembers.text = getString(R.string.team_members_format, team.ucount)
+        }
+    }
+
+    private fun showNoTeam(message: String) {
+        binding?.apply {
+            containerTeamInfo.visibility = View.GONE
+            textNoTeam.text = message
+            textNoTeam.visibility = View.VISIBLE
+        }
     }
 
     companion object {
-        // TODO: Rename parameter arguments, choose names that match
-        // the fragment initialization parameters, e.g. ARG_ITEM_NUMBER
         const val CATEGORY_NAME: String = "6ч"
         const val CATEGORY_CODE: String = "6h"
 
-        /**
-         * Use this factory method to create a new instance of
-         * this fragment using the provided parameters.
-         *
-         * @param param1 Parameter 1.
-         * @param param2 Parameter 2.
-         * @return A new instance of fragment DemoObjectFragment.
-         */
-        // TODO: Rename and change types and number of parameters
         fun newInstance(param1: String?, param2: String?): TeamsCategoryFragment {
             val fragment = TeamsCategoryFragment()
             val args = Bundle()

--- a/app/src/main/res/layout/activity_team_selection.xml
+++ b/app/src/main/res/layout/activity_team_selection.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".ui.teams.TeamSelectionActivity">
+
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/toolbar"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:background="?attr/colorPrimary"
+        android:theme="@style/ThemeOverlay.MaterialComponents.ActionBar"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+        android:id="@+id/swipeToRefresh"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/toolbar">
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/recycler_teams"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:scrollbars="vertical"
+            tools:listitem="@layout/team_item" />
+    </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
+
+    <TextView
+        android:id="@+id/text_no_teams"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_margin="16dp"
+        android:gravity="center"
+        android:text="@string/team_selection_empty"
+        android:textAppearance="@style/TextAppearance.MaterialComponents.Body1"
+        android:visibility="gone"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/toolbar" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_teams_category.xml
+++ b/app/src/main/res/layout/fragment_teams_category.xml
@@ -4,36 +4,119 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:padding="16dp"
     tools:context=".ui.teams.TeamsCategoryFragment">
 
-    <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
-        android:id="@+id/swipeToRefresh"
-        android:layout_width="match_parent"
+    <TextView
+        android:id="@+id/text_category_title"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
-        app:layout_constraintBottom_toBottomOf="parent"
+        android:textAppearance="@style/TextAppearance.MaterialComponents.Headline6"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent">
-
-        <androidx.recyclerview.widget.RecyclerView
-            android:id="@+id/recycler_teams"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:scrollbars="vertical"
-            tools:listitem="@layout/team_item" />
-    </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
+        app:layout_constraintTop_toTopOf="parent"
+        tools:text="Категория 6ч" />
 
     <TextView
-        android:id="@+id/text_no_teams"
-        android:layout_width="wrap_content"
+        android:id="@+id/text_current_team_title"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:text="Команды не загружены, обновите список, потянув вниз"
-        android:textSize="18sp"
-        android:gravity="center"
-        android:visibility="gone"
-        app:layout_constraintBottom_toBottomOf="parent"
+        android:layout_marginTop="12dp"
+        android:text="@string/current_team_title"
+        android:textAppearance="@style/TextAppearance.MaterialComponents.Subtitle1"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintTop_toBottomOf="@id/text_category_title" />
+
+    <LinearLayout
+        android:id="@+id/container_team_info"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:orientation="vertical"
+        android:visibility="gone"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/text_current_team_title">
+
+        <TextView
+            android:id="@+id/text_team_name"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:textAppearance="@style/TextAppearance.MaterialComponents.Body1"
+            tools:text="Команда \"Молния\"" />
+
+        <TextView
+            android:id="@+id/text_team_number"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            android:textAppearance="@style/TextAppearance.MaterialComponents.Body2"
+            tools:text="Стартовый номер: 123" />
+
+        <TextView
+            android:id="@+id/text_team_category"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            android:textAppearance="@style/TextAppearance.MaterialComponents.Body2"
+            tools:text="Категория: 6ч" />
+
+        <TextView
+            android:id="@+id/text_team_city"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            android:textAppearance="@style/TextAppearance.MaterialComponents.Body2"
+            tools:text="Город: Санкт-Петербург" />
+
+        <TextView
+            android:id="@+id/text_team_organization"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            android:textAppearance="@style/TextAppearance.MaterialComponents.Body2"
+            tools:text="Организация: Велоклуб" />
+
+        <TextView
+            android:id="@+id/text_team_members"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            android:textAppearance="@style/TextAppearance.MaterialComponents.Body2"
+            tools:text="Участников: 4" />
+    </LinearLayout>
+
+    <TextView
+        android:id="@+id/text_no_team"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:gravity="center_horizontal"
+        android:text="@string/team_not_selected_message"
+        android:textAppearance="@style/TextAppearance.MaterialComponents.Body2"
+        android:visibility="gone"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/text_current_team_title" />
+
+    <androidx.constraintlayout.widget.Barrier
+        android:id="@+id/barrier_team_content"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:barrierDirection="bottom"
+        app:constraint_referenced_ids="container_team_info,text_no_team" />
+
+    <Button
+        android:id="@+id/button_change_team"
+        style="@style/Widget.MaterialComponents.Button"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="24dp"
+        android:text="@string/change_team"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/barrier_team_content"
+        tools:layout_editor_absoluteY="200dp" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -36,4 +36,19 @@
     <string name="attachment_summary_off">Only download attachments when manually requested</string>
     <string name="settings">Настройки</string>
     <string name="tag_admin">Метки (Админ)</string>
+    <string name="current_team_title">Ваша команда</string>
+    <string name="team_category_title_format">Команды %1$s</string>
+    <string name="change_team">Изменить команду</string>
+    <string name="team_not_selected_message">Команда не выбрана</string>
+    <string name="team_not_found_message">Не удалось загрузить данные команды</string>
+    <string name="team_category_mismatch_message">Выбранная команда относится к другой категории</string>
+    <string name="team_number_format">Стартовый номер: %1$s</string>
+    <string name="team_category_format">Категория: %1$s</string>
+    <string name="team_city_format">Город: %1$s</string>
+    <string name="team_organization_format">Организация: %1$s</string>
+    <string name="team_members_format">Участников: %1$d</string>
+    <string name="team_info_not_specified">не указано</string>
+    <string name="team_selection_empty">Команды не найдены. Обновите список, потянув вниз.</string>
+    <string name="select_team_title">Выбор команды %1$s</string>
+    <string name="select_team_title_generic">Выбор команды</string>
 </resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -13,4 +13,11 @@
         <item name="android:statusBarColor" tools:targetApi="l">#55629E</item>
         <!-- Customize your theme here. -->
     </style>
+
+    <style name="Theme.Kolco24.NoActionBar" parent="Theme.Kolco24">
+        <item name="windowActionBar">false</item>
+        <item name="android:windowActionBar">false</item>
+        <item name="windowNoTitle">true</item>
+        <item name="android:windowNoTitle">true</item>
+    </style>
 </resources>


### PR DESCRIPTION
## Summary
- replace the teams category tab with current team details and a change-team entry point
- add a dedicated team selection activity and layout with refreshable team list
- register the new screen, extend the team view model API, and update shared resources

## Testing
- ./gradlew lint *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e20348faf88330ab09631d7ade5deb