### PR TITLE
feat: add debug-only reset team and clear database actions

### DIFF
--- a/app/src/main/java/ru/kolco24/kolco24/AppContainer.kt
+++ b/app/src/main/java/ru/kolco24/kolco24/AppContainer.kt
@@ -71,4 +71,11 @@ class AppContainer(private val context: Context) {
 
     /** Long-lived scope for fire-and-forget background work (e.g. startup refresh). */
     val applicationScope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+    /**
+     * Debug/testing only — wipes every Room table (races, categories, teams, selected_team,
+     * checkpoints) plus the `sync_meta` ETags, so the next refresh re-fetches everything from
+     * scratch. Blocking; call from a background dispatcher.
+     */
+    fun clearDatabase() = database.clearAllTables()
 }

--- a/app/src/main/java/ru/kolco24/kolco24/MainActivity.kt
+++ b/app/src/main/java/ru/kolco24/kolco24/MainActivity.kt
@@ -253,6 +253,24 @@ private fun Kolco24AppRoot() {
                     pickerRaceId = selectedRaceId
                     teamFlowStep = TeamFlowStep.CompPicker
                 },
+                onResetTeam = if (BuildConfig.DEBUG) {
+                    {
+                        // applicationScope (not composition scope) so the delete outlives the
+                        // closing overlay — same reasoning as selectTeam below.
+                        container.applicationScope.launch { teamRepo.clearSelectedTeam() }
+                        showSettings = false
+                    }
+                } else {
+                    null
+                },
+                onClearDatabase = if (BuildConfig.DEBUG) {
+                    {
+                        container.applicationScope.launch { container.clearDatabase() }
+                        showSettings = false
+                    }
+                } else {
+                    null
+                },
                 modifier = Modifier.fillMaxSize(),
             )
         }

--- a/app/src/main/java/ru/kolco24/kolco24/data/TeamRepository.kt
+++ b/app/src/main/java/ru/kolco24/kolco24/data/TeamRepository.kt
@@ -78,6 +78,14 @@ class TeamRepository(
     suspend fun selectTeam(raceId: Int, teamId: Int) {
         selectedTeamDao.upsert(SelectedTeamEntity(raceId = raceId, teamId = teamId))
     }
+
+    /**
+     * Clears the selected team, returning the app to the no-team state. Debug/testing only —
+     * leaves cached teams/legend/ETags intact, so it is a fast reset rather than a full wipe.
+     */
+    suspend fun clearSelectedTeam() {
+        selectedTeamDao.clear()
+    }
 }
 
 /** Maps a network DTO to the persisted entity, stamping the owning [raceId]. */

--- a/app/src/main/java/ru/kolco24/kolco24/data/db/SelectedTeamDao.kt
+++ b/app/src/main/java/ru/kolco24/kolco24/data/db/SelectedTeamDao.kt
@@ -12,4 +12,7 @@ interface SelectedTeamDao {
 
     @Upsert
     suspend fun upsert(selected: SelectedTeamEntity)
+
+    @Query("DELETE FROM selected_team")
+    suspend fun clear()
 }

--- a/app/src/main/java/ru/kolco24/kolco24/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/ru/kolco24/kolco24/ui/settings/SettingsScreen.kt
@@ -15,6 +15,8 @@ import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.ChevronRight
+import androidx.compose.material.icons.filled.DeleteSweep
+import androidx.compose.material.icons.filled.RestartAlt
 import androidx.compose.material.icons.filled.SwapHoriz
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
@@ -40,6 +42,8 @@ import androidx.compose.ui.unit.dp
 fun SettingsScreen(
     onBack: () -> Unit,
     onChangeTeam: () -> Unit,
+    onResetTeam: (() -> Unit)? = null,
+    onClearDatabase: (() -> Unit)? = null,
     modifier: Modifier = Modifier,
 ) {
     Column(modifier = modifier.background(MaterialTheme.colorScheme.surface).pointerInput(Unit) { detectTapGestures {} }) {
@@ -73,6 +77,91 @@ fun SettingsScreen(
         ) {
             ChangeTeamRow(onClick = onChangeTeam)
         }
+
+        // Debug-only: caller passes non-null callbacks only in debug builds (see MainActivity).
+        if (onResetTeam != null || onClearDatabase != null) {
+            Text(
+                text = "Отладка",
+                modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Surface(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 8.dp),
+                shape = MaterialTheme.shapes.large,
+                color = MaterialTheme.colorScheme.surfaceContainerLow,
+            ) {
+                Column {
+                    if (onResetTeam != null) {
+                        DebugRow(
+                            icon = Icons.Filled.RestartAlt,
+                            title = "Сбросить команду",
+                            subtitle = "Debug: вернуться к выбору команды",
+                            onClick = onResetTeam,
+                        )
+                    }
+                    if (onClearDatabase != null) {
+                        DebugRow(
+                            icon = Icons.Filled.DeleteSweep,
+                            title = "Очистить базу данных",
+                            subtitle = "Debug: удалить гонки, команды, легенду и ETag",
+                            onClick = onClearDatabase,
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+/** Debug-only action row — red avatar, title + subtitle, chevron. */
+@Composable
+private fun DebugRow(
+    icon: androidx.compose.ui.graphics.vector.ImageVector,
+    title: String,
+    subtitle: String,
+    onClick: () -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick)
+            .padding(horizontal = 16.dp, vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(14.dp),
+    ) {
+        Box(
+            modifier = Modifier
+                .size(40.dp)
+                .background(MaterialTheme.colorScheme.errorContainer, CircleShape),
+            contentAlignment = Alignment.Center,
+        ) {
+            Icon(
+                imageVector = icon,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onErrorContainer,
+                modifier = Modifier.size(20.dp),
+            )
+        }
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = title,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+            Text(
+                text = subtitle,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+        Icon(
+            imageVector = Icons.Filled.ChevronRight,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
     }
 }
 


### PR DESCRIPTION
Add two debug-build-only rows to the Settings overlay for testing:
- «Сбросить команду» clears the selected_team row, returning to the no-team state (TeamRepository.clearSelectedTeam / SelectedTeamDao.clear).
- «Очистить базу данных» wipes all Room tables + sync_meta ETags via AppContainer.clearDatabase (database.clearAllTables).

Rows are gated on nullable callbacks passed only when BuildConfig.DEBUG, keeping BuildConfig out of the UI module and the screen stateless.