### PR TITLE
feat: fix legend progress bar with server total_cost

### DIFF
--- a/app/schemas/ru.kolco24.kolco24.data.db.AppDatabase/9.json
+++ b/app/schemas/ru.kolco24.kolco24.data.db.AppDatabase/9.json
@@ -1,0 +1,649 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 9,
+    "identityHash": "2157a1b0220b26559cf0ae437d2bcb23",
+    "entities": [
+      {
+        "tableName": "races",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `name` TEXT NOT NULL, `slug` TEXT NOT NULL, `date` TEXT NOT NULL, `dateEnd` TEXT, `place` TEXT NOT NULL, `regStatus` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "slug",
+            "columnName": "slug",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "date",
+            "columnName": "date",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dateEnd",
+            "columnName": "dateEnd",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "place",
+            "columnName": "place",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "regStatus",
+            "columnName": "regStatus",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "sync_meta",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`origin` TEXT NOT NULL, `resource` TEXT NOT NULL, `etag` TEXT NOT NULL, PRIMARY KEY(`origin`, `resource`))",
+        "fields": [
+          {
+            "fieldPath": "origin",
+            "columnName": "origin",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "resource",
+            "columnName": "resource",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "etag",
+            "columnName": "etag",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "origin",
+            "resource"
+          ]
+        }
+      },
+      {
+        "tableName": "categories",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `raceId` INTEGER NOT NULL, `code` TEXT NOT NULL, `shortName` TEXT NOT NULL, `name` TEXT NOT NULL, `sortOrder` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "raceId",
+            "columnName": "raceId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "code",
+            "columnName": "code",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "shortName",
+            "columnName": "shortName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sortOrder",
+            "columnName": "sortOrder",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "teams",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `raceId` INTEGER NOT NULL, `teamname` TEXT NOT NULL, `startNumber` TEXT, `categoryId` INTEGER, `ucount` INTEGER NOT NULL, `paidPeople` REAL NOT NULL, `startTime` INTEGER NOT NULL, `finishTime` INTEGER NOT NULL, `members` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "raceId",
+            "columnName": "raceId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "teamname",
+            "columnName": "teamname",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startNumber",
+            "columnName": "startNumber",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "categoryId",
+            "columnName": "categoryId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "ucount",
+            "columnName": "ucount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "paidPeople",
+            "columnName": "paidPeople",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startTime",
+            "columnName": "startTime",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "finishTime",
+            "columnName": "finishTime",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "members",
+            "columnName": "members",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_teams_raceId",
+            "unique": false,
+            "columnNames": [
+              "raceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_teams_raceId` ON `${TABLE_NAME}` (`raceId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "selected_team",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `raceId` INTEGER NOT NULL, `teamId` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "raceId",
+            "columnName": "raceId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "teamId",
+            "columnName": "teamId",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "checkpoints",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `raceId` INTEGER NOT NULL, `number` INTEGER NOT NULL, `cost` INTEGER, `type` TEXT NOT NULL, `description` TEXT, `locked` INTEGER NOT NULL, `encIv` TEXT, `encCt` TEXT, `color` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "raceId",
+            "columnName": "raceId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "number",
+            "columnName": "number",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cost",
+            "columnName": "cost",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "locked",
+            "columnName": "locked",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "encIv",
+            "columnName": "encIv",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "encCt",
+            "columnName": "encCt",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "color",
+            "columnName": "color",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_checkpoints_raceId",
+            "unique": false,
+            "columnNames": [
+              "raceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_checkpoints_raceId` ON `${TABLE_NAME}` (`raceId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "tags",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`raceId` INTEGER NOT NULL, `bid` TEXT NOT NULL, `point` INTEGER NOT NULL, `checkMethod` TEXT NOT NULL, `iv` TEXT, `ct` TEXT, PRIMARY KEY(`raceId`, `bid`))",
+        "fields": [
+          {
+            "fieldPath": "raceId",
+            "columnName": "raceId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bid",
+            "columnName": "bid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "point",
+            "columnName": "point",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "checkMethod",
+            "columnName": "checkMethod",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "iv",
+            "columnName": "iv",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "ct",
+            "columnName": "ct",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "raceId",
+            "bid"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_tags_raceId",
+            "unique": false,
+            "columnNames": [
+              "raceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_tags_raceId` ON `${TABLE_NAME}` (`raceId`)"
+          },
+          {
+            "name": "index_tags_point",
+            "unique": false,
+            "columnNames": [
+              "point"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_tags_point` ON `${TABLE_NAME}` (`point`)"
+          }
+        ]
+      },
+      {
+        "tableName": "member_tags",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`raceId` INTEGER NOT NULL, `nfcUid` TEXT NOT NULL, `number` INTEGER NOT NULL, PRIMARY KEY(`raceId`, `nfcUid`))",
+        "fields": [
+          {
+            "fieldPath": "raceId",
+            "columnName": "raceId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nfcUid",
+            "columnName": "nfcUid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "number",
+            "columnName": "number",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "raceId",
+            "nfcUid"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_member_tags_raceId",
+            "unique": false,
+            "columnNames": [
+              "raceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_member_tags_raceId` ON `${TABLE_NAME}` (`raceId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "member_chip_bindings",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`teamId` INTEGER NOT NULL, `numberInTeam` INTEGER NOT NULL, `nfcUid` TEXT NOT NULL, `participantNumber` INTEGER NOT NULL, PRIMARY KEY(`teamId`, `numberInTeam`))",
+        "fields": [
+          {
+            "fieldPath": "teamId",
+            "columnName": "teamId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "numberInTeam",
+            "columnName": "numberInTeam",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nfcUid",
+            "columnName": "nfcUid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "participantNumber",
+            "columnName": "participantNumber",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "teamId",
+            "numberInTeam"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_member_chip_bindings_nfcUid",
+            "unique": false,
+            "columnNames": [
+              "nfcUid"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_member_chip_bindings_nfcUid` ON `${TABLE_NAME}` (`nfcUid`)"
+          }
+        ]
+      },
+      {
+        "tableName": "marks",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `raceId` INTEGER NOT NULL, `teamId` INTEGER NOT NULL, `point` INTEGER NOT NULL, `checkpointNumber` INTEGER NOT NULL, `cost` INTEGER NOT NULL, `method` TEXT NOT NULL, `cpUid` TEXT NOT NULL, `cpCode` TEXT NOT NULL, `present` TEXT NOT NULL, `expectedCount` INTEGER NOT NULL, `complete` INTEGER NOT NULL, `photoPath` TEXT, `takenAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `uploadedLocal` INTEGER NOT NULL, `uploadedCloud` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "raceId",
+            "columnName": "raceId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "teamId",
+            "columnName": "teamId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "point",
+            "columnName": "point",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "checkpointNumber",
+            "columnName": "checkpointNumber",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cost",
+            "columnName": "cost",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "method",
+            "columnName": "method",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cpUid",
+            "columnName": "cpUid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cpCode",
+            "columnName": "cpCode",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "present",
+            "columnName": "present",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "expectedCount",
+            "columnName": "expectedCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "complete",
+            "columnName": "complete",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "photoPath",
+            "columnName": "photoPath",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "takenAt",
+            "columnName": "takenAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "uploadedLocal",
+            "columnName": "uploadedLocal",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "uploadedCloud",
+            "columnName": "uploadedCloud",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_marks_teamId",
+            "unique": false,
+            "columnNames": [
+              "teamId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_marks_teamId` ON `${TABLE_NAME}` (`teamId`)"
+          },
+          {
+            "name": "index_marks_point",
+            "unique": false,
+            "columnNames": [
+              "point"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_marks_point` ON `${TABLE_NAME}` (`point`)"
+          }
+        ]
+      },
+      {
+        "tableName": "legend_meta",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`raceId` INTEGER NOT NULL, `totalCost` INTEGER NOT NULL, PRIMARY KEY(`raceId`))",
+        "fields": [
+          {
+            "fieldPath": "raceId",
+            "columnName": "raceId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalCost",
+            "columnName": "totalCost",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "raceId"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '2157a1b0220b26559cf0ae437d2bcb23')"
+    ]
+  }
+}

--- a/app/src/androidTest/java/ru/kolco24/kolco24/data/db/MigrationTest.kt
+++ b/app/src/androidTest/java/ru/kolco24/kolco24/data/db/MigrationTest.kt
@@ -600,6 +600,73 @@ class MigrationTest {
     }
 
     @Test
+    fun migrate8To9_keepsDataAndAddsLegendMetaTable() {
+        val dbName = "migration-8to9-test.db"
+
+        // Reach v8, then seed a race + a checkpoint so we can assert existing data survives.
+        helper.createDatabase(dbName, 1).close()
+        helper.runMigrationsAndValidate(
+            dbName,
+            8,
+            true,
+            AppDatabase.MIGRATION_1_2,
+            AppDatabase.MIGRATION_2_3,
+            AppDatabase.MIGRATION_3_4,
+            AppDatabase.MIGRATION_4_5,
+            AppDatabase.MIGRATION_5_6,
+            AppDatabase.MIGRATION_6_7,
+            AppDatabase.MIGRATION_7_8,
+        ).use { db ->
+            db.execSQL(
+                "INSERT INTO races (id, name, slug, date, dateEnd, place, regStatus) " +
+                    "VALUES (7, 'Кольцо', 'kolco', '2026-08-01', NULL, 'Лес', 'open')"
+            )
+            db.execSQL(
+                "INSERT INTO checkpoints (id, raceId, number, cost, type, description, locked, encIv, encCt, color) " +
+                    "VALUES (1, 7, 5, 10, 'kp', 'У пня', 0, NULL, NULL, '')"
+            )
+        }
+
+        // Run 8→9; MigrationTestHelper validates the resulting schema against 9.json.
+        val db = helper.runMigrationsAndValidate(
+            dbName,
+            9,
+            true,
+            AppDatabase.MIGRATION_1_2,
+            AppDatabase.MIGRATION_2_3,
+            AppDatabase.MIGRATION_3_4,
+            AppDatabase.MIGRATION_4_5,
+            AppDatabase.MIGRATION_5_6,
+            AppDatabase.MIGRATION_6_7,
+            AppDatabase.MIGRATION_7_8,
+            AppDatabase.MIGRATION_8_9,
+        )
+
+        // Existing rows survive the additive migration.
+        db.query("SELECT name FROM races WHERE id = 7").use { cursor ->
+            assertTrue(cursor.moveToFirst())
+            assertEquals("Кольцо", cursor.getString(0))
+        }
+        db.query("SELECT description FROM checkpoints WHERE id = 1").use { cursor ->
+            assertTrue(cursor.moveToFirst())
+            assertEquals("У пня", cursor.getString(0))
+        }
+
+        // New table exists, is empty, and accepts the entity column set — a camelCase/snake_case
+        // mismatch only surfaces here.
+        db.query("SELECT count(*) FROM legend_meta").use { cursor ->
+            assertTrue(cursor.moveToFirst())
+            assertEquals(0, cursor.getInt(0))
+        }
+        db.execSQL("INSERT INTO legend_meta (raceId, totalCost) VALUES (7, 42)")
+        db.query("SELECT totalCost FROM legend_meta WHERE raceId = 7").use { cursor ->
+            assertTrue(cursor.moveToFirst())
+            assertEquals(42, cursor.getInt(0))
+        }
+        db.close()
+    }
+
+    @Test
     fun migrate2To3_indexExists() {
         val dbName = "migration-2to3-index-test.db"
         helper.createDatabase(dbName, 1).close()

--- a/app/src/main/java/ru/kolco24/kolco24/AppContainer.kt
+++ b/app/src/main/java/ru/kolco24/kolco24/AppContainer.kt
@@ -83,6 +83,7 @@ class AppContainer(private val context: Context) {
             apiClient = apiClient,
             checkpointDao = database.checkpointDao(),
             tagDao = database.tagDao(),
+            legendMetaDao = database.legendMetaDao(),
             syncMetaDao = database.syncMetaDao(),
             origin = baseUrl,
             json = json,

--- a/app/src/main/java/ru/kolco24/kolco24/MainActivity.kt
+++ b/app/src/main/java/ru/kolco24/kolco24/MainActivity.kt
@@ -426,6 +426,12 @@ private fun Kolco24AppRoot(
     // prior race during the brief window before the new flow emits (mirrors the safeMarks guard).
     val safeCheckpoints = if (selectedRaceId != null) legendCheckpoints.filter { it.raceId == selectedRaceId } else emptyList()
 
+    // Legend progress denominator: sum of ALL CP costs (open + locked), from the server's
+    // `total_cost` (locked CPs hide their individual cost, so it can't be summed client-side).
+    val legendTotalCost by remember(selectedRaceId) {
+        selectedRaceId?.let { legendRepo.totalCostForRace(it) } ?: flowOf(0)
+    }.collectAsState(initial = 0)
+
     // Local NFC chip bindings for the selected team, keyed by member slot (numberInTeam).
     val bindingsList by remember(selectedTeamId) {
         selectedTeamId?.let { bindingRepo.observeForTeam(it) } ?: flowOf(emptyList())
@@ -581,6 +587,7 @@ private fun Kolco24AppRoot(
                         hasTeam = teamState !is SelectedTeamState.None,
                         onChooseTeam = { pickerRaceId = null; teamFlowStep = TeamFlowStep.CompPicker },
                         takenIds = takenIds,
+                        totalScore = legendTotalCost,
                         modifier = Modifier.padding(bottom = innerPadding.calculateBottomPadding()),
                     )
                     2 -> TeamScreen(

--- a/app/src/main/java/ru/kolco24/kolco24/data/LegendRepository.kt
+++ b/app/src/main/java/ru/kolco24/kolco24/data/LegendRepository.kt
@@ -12,8 +12,11 @@ import ru.kolco24.kolco24.data.crypto.EncBlob
 import ru.kolco24.kolco24.data.crypto.LegendCrypto
 import ru.kolco24.kolco24.data.crypto.UnlockResult
 import ru.kolco24.kolco24.data.crypto.UnlockTag
+import kotlinx.coroutines.flow.map
 import ru.kolco24.kolco24.data.db.CheckpointDao
 import ru.kolco24.kolco24.data.db.CheckpointEntity
+import ru.kolco24.kolco24.data.db.LegendMetaDao
+import ru.kolco24.kolco24.data.db.LegendMetaEntity
 import ru.kolco24.kolco24.data.db.SyncMetaDao
 import ru.kolco24.kolco24.data.db.SyncMetaEntity
 import ru.kolco24.kolco24.data.db.TagDao
@@ -37,6 +40,7 @@ class LegendRepository(
     private val apiClient: ApiClient,
     private val checkpointDao: CheckpointDao,
     private val tagDao: TagDao,
+    private val legendMetaDao: LegendMetaDao,
     private val syncMetaDao: SyncMetaDao,
     private val origin: String,
     private val json: Json,
@@ -44,6 +48,15 @@ class LegendRepository(
     /** Offline-readable checkpoints of one race, ordered by number then id. */
     fun checkpointsForRace(raceId: Int): Flow<List<CheckpointEntity>> =
         checkpointDao.observeCheckpointsForRace(raceId)
+
+    /**
+     * Offline-readable sum of **all** checkpoint costs of one race (open + locked) — the correct
+     * denominator for the legend progress bar. Emits `0` until the first `200` populates `legend_meta`
+     * (no row yet), which collapses the bar to 0% rather than skewing it; the server always sends the
+     * field, so this is only the pre-sync window.
+     */
+    fun totalCostForRace(raceId: Int): Flow<Int> =
+        legendMetaDao.observeForRace(raceId).map { it?.totalCost ?: 0 }
 
     /** One-shot snapshot — re-reads after an offline [unlock] to get the just-revealed cost. */
     suspend fun checkpointsSnapshot(raceId: Int): List<CheckpointEntity> =
@@ -76,6 +89,7 @@ class LegendRepository(
                     raceId = raceId,
                     tags = response.tags.map { it.toEntity(raceId) },
                 )
+                legendMetaDao.upsert(LegendMetaEntity(raceId, response.totalCost))
                 if (result.etag != null) {
                     syncMetaDao.upsert(SyncMetaEntity(origin, resource, result.etag))
                 }

--- a/app/src/main/java/ru/kolco24/kolco24/data/api/dto/LegendResponse.kt
+++ b/app/src/main/java/ru/kolco24/kolco24/data/api/dto/LegendResponse.kt
@@ -3,10 +3,17 @@ package ru.kolco24.kolco24.data.api.dto
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
-/** Top-level payload of `GET /app/race/<race_id>/legend/` (see docs/design/API.md). */
+/**
+ * Top-level payload of `GET /app/race/<race_id>/legend/` (see docs/design/API.md).
+ *
+ * [totalCost] is the sum of **every** checkpoint's `cost` — open AND locked — so the legend progress
+ * bar has a correct denominator even when locked CPs hide their individual `cost`. Defaulted to `0`
+ * for forward-compat (a payload without the field parses safely); persisted per-race in `legend_meta`.
+ */
 @Serializable
 data class LegendResponse(
     val race: Int,
+    @SerialName("total_cost") val totalCost: Int = 0,
     val checkpoints: List<CheckpointDto>,
     val tags: List<TagDto> = emptyList(),
 )

--- a/app/src/main/java/ru/kolco24/kolco24/data/db/AppDatabase.kt
+++ b/app/src/main/java/ru/kolco24/kolco24/data/db/AppDatabase.kt
@@ -20,8 +20,9 @@ import androidx.sqlite.db.SupportSQLiteDatabase
         MemberTagEntity::class,
         MemberChipBindingEntity::class,
         MarkEntity::class,
+        LegendMetaEntity::class,
     ],
-    version = 8,
+    version = 9,
     exportSchema = true,
 )
 @TypeConverters(TeamMembersConverter::class, IntListConverter::class)
@@ -35,6 +36,7 @@ abstract class AppDatabase : RoomDatabase() {
     abstract fun memberTagDao(): MemberTagDao
     abstract fun memberChipBindingDao(): MemberChipBindingDao
     abstract fun markDao(): MarkDao
+    abstract fun legendMetaDao(): LegendMetaDao
 
     companion object {
         /**
@@ -249,6 +251,21 @@ abstract class AppDatabase : RoomDatabase() {
             }
         }
 
+        /**
+         * Adds the `legend_meta` table — a race-level aggregate ([LegendMetaEntity]) holding the
+         * legend's `total_cost`. Purely additive (a plain `CREATE TABLE`, like [MIGRATION_4_5]); no
+         * existing table is touched, so all prior data survives the upgrade. SQL must match Room's
+         * generated schema (see schemas/.../9.json) exactly, or the validation check fails at runtime.
+         */
+        val MIGRATION_8_9 = object : Migration(8, 9) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL(
+                    "CREATE TABLE IF NOT EXISTS `legend_meta` (`raceId` INTEGER NOT NULL, " +
+                        "`totalCost` INTEGER NOT NULL, PRIMARY KEY(`raceId`))"
+                )
+            }
+        }
+
         fun build(context: Context): AppDatabase =
             Room.databaseBuilder(
                 context.applicationContext,
@@ -263,6 +280,7 @@ abstract class AppDatabase : RoomDatabase() {
                     MIGRATION_5_6,
                     MIGRATION_6_7,
                     MIGRATION_7_8,
+                    MIGRATION_8_9,
                 )
                 .build()
     }

--- a/app/src/main/java/ru/kolco24/kolco24/data/db/LegendMetaDao.kt
+++ b/app/src/main/java/ru/kolco24/kolco24/data/db/LegendMetaDao.kt
@@ -1,0 +1,15 @@
+package ru.kolco24.kolco24.data.db
+
+import androidx.room.Dao
+import androidx.room.Query
+import androidx.room.Upsert
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface LegendMetaDao {
+    @Query("SELECT * FROM legend_meta WHERE raceId = :raceId")
+    fun observeForRace(raceId: Int): Flow<LegendMetaEntity?>
+
+    @Upsert
+    suspend fun upsert(meta: LegendMetaEntity)
+}

--- a/app/src/main/java/ru/kolco24/kolco24/data/db/LegendMetaEntity.kt
+++ b/app/src/main/java/ru/kolco24/kolco24/data/db/LegendMetaEntity.kt
@@ -1,0 +1,21 @@
+package ru.kolco24.kolco24.data.db
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+/**
+ * Race-level aggregate of the legend that has no per-checkpoint home. Currently just [totalCost] —
+ * the sum of **every** checkpoint's `cost` (open + locked) as reported by the server in the legend
+ * response's top-level `total_cost` field.
+ *
+ * It exists because a **locked** checkpoint hides its individual `cost` (the plaintext never leaves
+ * the server), so the client cannot compute the full denominator for the legend progress bar from
+ * [CheckpointEntity] rows alone. The server-supplied aggregate is the only correct denominator; this
+ * row persists it (one per race, keyed by [raceId]) so the legend reads it offline like the rest of
+ * the data. Written by `LegendRepository.refreshLegend` alongside the checkpoints/tags.
+ */
+@Entity(tableName = "legend_meta")
+data class LegendMetaEntity(
+    @PrimaryKey val raceId: Int,
+    val totalCost: Int,
+)

--- a/app/src/main/java/ru/kolco24/kolco24/ui/legend/LegendScreen.kt
+++ b/app/src/main/java/ru/kolco24/kolco24/ui/legend/LegendScreen.kt
@@ -86,6 +86,7 @@ fun LegendScreen(
     hasTeam: Boolean,
     onChooseTeam: () -> Unit,
     takenIds: Set<Int> = emptySet(),
+    totalScore: Int = 0,
     modifier: Modifier = Modifier,
 ) {
     Column(modifier = modifier.fillMaxSize()) {
@@ -98,23 +99,24 @@ fun LegendScreen(
 
         when {
             !hasTeam -> LegendNoTeam(onChooseTeam = onChooseTeam)
-            else -> LegendList(checkpoints = checkpoints, takenIds = takenIds)
+            else -> LegendList(checkpoints = checkpoints, takenIds = takenIds, totalScore = totalScore)
         }
     }
 }
 
 @Composable
-private fun LegendList(checkpoints: List<CheckpointEntity>, takenIds: Set<Int>) {
+private fun LegendList(checkpoints: List<CheckpointEntity>, takenIds: Set<Int>, totalScore: Int) {
     var showOnlyOpen by rememberSaveable { mutableStateOf(false) }
 
     val visible = if (showOnlyOpen) checkpoints.filter { it.id !in takenIds } else checkpoints
 
     val takenCount = checkpoints.count { it.id in takenIds }
     val totalCount = checkpoints.size
-    // cost is nullable now (locked CPs hide it until unlocked); sum only the known costs. Locked-
-    // unrevealed CPs are surfaced as a «+N закрытых КП» hint instead of skewing the score.
+    // The numerator sums known costs of taken CPs (taking a locked CP reveals its cost). The
+    // denominator [totalScore] is the server's `total_cost` — sum of ALL CP costs, incl. locked
+    // ones whose individual cost is hidden — so the bar can't fill to 100% before locked CPs are
+    // taken. Locked-unrevealed CPs are surfaced as a «+N закрытых КП» hint via [lockedCount].
     val takenScore = checkpoints.filter { it.id in takenIds }.mapNotNull { it.cost }.sum()
-    val totalScore = checkpoints.mapNotNull { it.cost }.sum()
     val lockedCount = checkpoints.count { it.locked }
 
     LazyColumn(

--- a/app/src/test/java/ru/kolco24/kolco24/data/LegendRepositoryTest.kt
+++ b/app/src/test/java/ru/kolco24/kolco24/data/LegendRepositoryTest.kt
@@ -24,6 +24,8 @@ import ru.kolco24.kolco24.data.crypto.EncBlob
 import ru.kolco24.kolco24.data.crypto.LegendCrypto
 import ru.kolco24.kolco24.data.db.CheckpointDao
 import ru.kolco24.kolco24.data.db.CheckpointEntity
+import ru.kolco24.kolco24.data.db.LegendMetaDao
+import ru.kolco24.kolco24.data.db.LegendMetaEntity
 import ru.kolco24.kolco24.data.db.SyncMetaDao
 import ru.kolco24.kolco24.data.db.SyncMetaEntity
 import ru.kolco24.kolco24.data.db.TagDao
@@ -38,6 +40,7 @@ class LegendRepositoryTest {
     private lateinit var server: MockWebServer
     private lateinit var checkpointDao: FakeCheckpointDao
     private lateinit var tagDao: FakeTagDao
+    private lateinit var legendMetaDao: FakeLegendMetaDao
     private lateinit var syncMetaDao: FakeLegendSyncMetaDao
     private lateinit var repository: LegendRepository
     private lateinit var origin: String
@@ -45,8 +48,12 @@ class LegendRepositoryTest {
     private val json = Json { ignoreUnknownKeys = true }
     private val callLog = mutableListOf<String>()
 
-    private fun legendJson(raceId: Int = 8, checkpointIds: List<Int> = listOf(101)) = buildString {
-        append("""{"race":$raceId,"checkpoints":[""")
+    private fun legendJson(
+        raceId: Int = 8,
+        checkpointIds: List<Int> = listOf(101),
+        totalCost: Int = 10,
+    ) = buildString {
+        append("""{"race":$raceId,"total_cost":$totalCost,"checkpoints":[""")
         checkpointIds.forEachIndexed { index, id ->
             if (index > 0) append(",")
             append("""{"id":$id,"number":${index + 1},"cost":10,"type":"kp","description":"КП $id"}""")
@@ -69,8 +76,9 @@ class LegendRepositoryTest {
         val apiClient = ApiClient(origin, OkHttpClient.Builder().addInterceptor(interceptor).build(), json)
         checkpointDao = FakeCheckpointDao(callLog)
         tagDao = FakeTagDao(callLog)
+        legendMetaDao = FakeLegendMetaDao(callLog)
         syncMetaDao = FakeLegendSyncMetaDao(callLog)
-        repository = LegendRepository(apiClient, checkpointDao, tagDao, syncMetaDao, origin, json)
+        repository = LegendRepository(apiClient, checkpointDao, tagDao, legendMetaDao, syncMetaDao, origin, json)
     }
 
     @After
@@ -123,7 +131,7 @@ class LegendRepositoryTest {
 
         repository.refreshLegend(8)
 
-        assertEquals(listOf("replaceAllForRace", "replaceAllTags", "upsertEtag"), callLog)
+        assertEquals(listOf("replaceAllForRace", "replaceAllTags", "upsertLegendMeta", "upsertEtag"), callLog)
     }
 
     @Test
@@ -134,7 +142,24 @@ class LegendRepositoryTest {
 
         assertEquals(1, repository.checkpointsForRace(8).first().size)
         assertNull(syncMetaDao.getEtag(origin, "race/8/legend"))
-        assertEquals(listOf("replaceAllForRace", "replaceAllTags"), callLog)
+        assertEquals(listOf("replaceAllForRace", "replaceAllTags", "upsertLegendMeta"), callLog)
+    }
+
+    @Test
+    fun success_persistsTotalCost() = runTest {
+        server.enqueue(
+            MockResponse().setResponseCode(200)
+                .setBody(legendJson(checkpointIds = listOf(101, 102), totalCost = 42)),
+        )
+
+        repository.refreshLegend(8)
+
+        assertEquals(42, repository.totalCostForRace(8).first())
+    }
+
+    @Test
+    fun totalCost_defaultsToZeroBeforeSync() = runTest {
+        assertEquals(0, repository.totalCostForRace(8).first())
     }
 
     @Test
@@ -439,6 +464,18 @@ private class FakeTagDao(private val callLog: MutableList<String>) : TagDao {
         deleteTagsForRace(raceId)
         insertTags(tags)
         callLog.add("replaceAllTags")
+    }
+}
+
+private class FakeLegendMetaDao(private val callLog: MutableList<String>) : LegendMetaDao {
+    private val store = MutableStateFlow<List<LegendMetaEntity>>(emptyList())
+
+    override fun observeForRace(raceId: Int): Flow<LegendMetaEntity?> =
+        store.map { list -> list.firstOrNull { it.raceId == raceId } }
+
+    override suspend fun upsert(meta: LegendMetaEntity) {
+        store.value = store.value.filterNot { it.raceId == meta.raceId } + meta
+        callLog.add("upsertLegendMeta")
     }
 }
 


### PR DESCRIPTION
The legend progress bar summed only known checkpoint costs for the denominator. Locked CPs hide their cost (cost == null), so once all revealed CPs were taken the bar showed 100% even with locked CPs still uncaught.

Add a server-supplied `total_cost` aggregate (sum of all CP costs, open
+ locked) to the legend response and use it as the denominator. Locked costs stay hidden — only the aggregate is exposed.

- Room v9: legend_meta(raceId, totalCost) + MIGRATION_8_9 (additive)
- LegendResponse.totalCost (@SerialName total_cost, default 0)
- LegendRepository persists it + exposes totalCostForRace flow
- LegendScreen takes totalScore param; drops client-side denominator
- API.md documents the contract
- Tests: total_cost persistence, migrate8To9 guard