### PR TITLE
fix: score Отметки off live КП cost, not stale snapshot

### DIFF
--- a/app/src/main/java/ru/kolco24/kolco24/MainActivity.kt
+++ b/app/src/main/java/ru/kolco24/kolco24/MainActivity.kt
@@ -496,6 +496,13 @@ private fun Kolco24AppRoot(
     // Per-checkpoint color token (point id → server color), so «Отметки» tiles can paint the same
     // leading color bar the Легенда rows use. Race-scoped public data, joined off the mark's point.
     val checkpointColors = remember(safeCheckpoints) { safeCheckpoints.associate { it.id to it.color } }
+    // Live per-checkpoint cost (point id → current cost), so «Отметки» СУММА/tiles score off the latest
+    // legend value rather than the cost snapshotted onto the mark row at take time (which goes stale if
+    // the organizer edits a КП cost afterwards). Locked CPs (null cost) are omitted; the mark snapshot
+    // fills in for any point missing from the map.
+    val checkpointCosts = remember(safeCheckpoints) {
+        safeCheckpoints.mapNotNull { cp -> cp.cost?.let { cp.id to it } }.toMap()
+    }
 
     // Flow overlay state — survives recreation (enum is Serializable; nullable Int saves out of the box).
     var teamFlowStep by rememberSaveable { mutableStateOf(TeamFlowStep.None) }
@@ -588,6 +595,7 @@ private fun Kolco24AppRoot(
                     0 -> MarksScreen(
                         marks = safeMarks,
                         checkpointColors = checkpointColors,
+                        checkpointCosts = checkpointCosts,
                         totalKp = safeCheckpoints.size,
                         totalCost = legendTotalCost,
                         nfcAvailable = nfcActiveForScan,

--- a/app/src/main/java/ru/kolco24/kolco24/data/MarkRepository.kt
+++ b/app/src/main/java/ru/kolco24/kolco24/data/MarkRepository.kt
@@ -96,6 +96,19 @@ fun takenPointCount(marks: List<MarkEntity>): Int =
 fun takenPoints(marks: List<MarkEntity>): Set<Int> =
     marks.filter { it.complete }.mapTo(HashSet()) { it.point }
 
-/** Sum of cost over distinct scored checkpoints — a repeat take of the same point does not double-count. */
-fun totalScore(marks: List<MarkEntity>): Int =
-    marks.filter { it.complete }.distinctBy { it.point }.sumOf { it.cost }
+/**
+ * Sum of cost over distinct scored checkpoints — a repeat take of the same point does not double-count.
+ * Uses the cost snapshotted onto the mark row at take time. Prefer the [costOf] overload for any
+ * user-facing total: the snapshot goes stale if the organizer edits a КП cost after it was taken (a
+ * 0→5 edit leaves the snapshot at 0), which makes the «Отметки» СУММА diverge from the «Легенда» score.
+ */
+fun totalScore(marks: List<MarkEntity>): Int = totalScore(marks) { it.cost }
+
+/**
+ * Sum of cost over distinct scored checkpoints using a **live** cost resolver instead of the snapshot
+ * baked into the mark row. [costOf] returns the current checkpoint cost for a take (the legend's live
+ * `CheckpointEntity.cost`), falling back to the mark's snapshot when the point is absent from the
+ * legend. This keeps the «Отметки» СУММА in step with the «Легенда» score after a server cost edit.
+ */
+fun totalScore(marks: List<MarkEntity>, costOf: (MarkEntity) -> Int): Int =
+    marks.filter { it.complete }.distinctBy { it.point }.sumOf { costOf(it) }

--- a/app/src/main/java/ru/kolco24/kolco24/ui/marks/MarksScreen.kt
+++ b/app/src/main/java/ru/kolco24/kolco24/ui/marks/MarksScreen.kt
@@ -79,12 +79,15 @@ enum class MarkKind { NFC, PHOTO }
  * row that is kept in the DB for the future server log but never tiled here, matching the
  * `complete`-only «ВЗЯТО»/«СУММА» metrics. [marks] arrives newest-first (as `observeMarks` delivers);
  * the tiles are returned **oldest-first** so a new take appends to the end of the grid rather than the
- * front. [colorOf] resolves a take's checkpoint color token (point id → server token) for the tile's
+ * front. [costOf] resolves a take's **live** checkpoint cost (point id → current cost) so a tile reflects
+ * an organizer's cost edit rather than the stale snapshot on the mark row (defaults to the snapshot).
+ * [colorOf] resolves a take's checkpoint color token (point id → server token) for the tile's
  * top color bar; it defaults to «no color» so the pure mapping stays testable without a checkpoint
  * map. Uses [SimpleDateFormat] (not `java.time`) for minSdk-24/no-desugaring compatibility.
  */
 fun marksToTiles(
     marks: List<MarkEntity>,
+    costOf: (MarkEntity) -> Int = { it.cost },
     colorOf: (MarkEntity) -> CheckpointColor? = { null },
 ): List<Mark> {
     val fmt = SimpleDateFormat("HH:mm", Locale.US)
@@ -94,7 +97,7 @@ fun marksToTiles(
         .map { m ->
             Mark(
                 number = m.checkpointNumber.toString().padStart(2, '0'),
-                cost = m.cost,
+                cost = costOf(m),
                 kind = if (m.method == "photo") MarkKind.PHOTO else MarkKind.NFC,
                 time = fmt.format(Date(m.takenAt)),
                 color = colorOf(m),
@@ -124,6 +127,7 @@ private fun CheckpointColor.barColor(): Color = when (this) {
 fun MarksScreen(
     marks: List<MarkEntity> = emptyList(),
     checkpointColors: Map<Int, String> = emptyMap(),
+    checkpointCosts: Map<Int, Int> = emptyMap(),
     totalKp: Int = 0,
     totalCost: Int = 0,
     nfcAvailable: Boolean = true,
@@ -131,8 +135,12 @@ fun MarksScreen(
     modifier: Modifier = Modifier,
 ) {
     val takenKp = takenPointCount(marks)
-    val takenScore = totalScore(marks)
-    val tiles = marksToTiles(marks) { parseCheckpointColor(checkpointColors[it.point] ?: "") }
+    // Score off the live checkpoint cost (joined by point id), falling back to the mark's snapshot for
+    // a point dropped from the legend — so СУММА tracks the «Легенда» score after an organizer cost edit
+    // rather than the stale value baked into the mark row.
+    val costOf: (MarkEntity) -> Int = { checkpointCosts[it.point] ?: it.cost }
+    val takenScore = totalScore(marks, costOf)
+    val tiles = marksToTiles(marks, costOf) { parseCheckpointColor(checkpointColors[it.point] ?: "") }
 
     Column(modifier = modifier.fillMaxSize()) {
         TopAppBar(

--- a/app/src/test/java/ru/kolco24/kolco24/ui/marks/MarksMappingTest.kt
+++ b/app/src/test/java/ru/kolco24/kolco24/ui/marks/MarksMappingTest.kt
@@ -137,4 +137,39 @@ class MarksMappingTest {
         assertEquals(2, takenPointCount(marks))
         assertEquals(5, totalScore(marks)) // 2 + 3, repeat of point 1 not double-counted
     }
+
+    @Test
+    fun `totalScore with a live cost resolver scores off current cost not the snapshot`() {
+        // Point 1 was taken when its cost was 0 (stale snapshot); the legend now says 5.
+        val marks = listOf(
+            mark("a", point = 1, number = 1, cost = 0, complete = true),
+            mark("b", point = 2, number = 4, cost = 3, complete = true),
+        )
+        val liveCost = mapOf(1 to 5, 2 to 3)
+        // Snapshot path under-counts (0 + 3); the live resolver matches the legend (5 + 3).
+        assertEquals(3, totalScore(marks))
+        assertEquals(8, totalScore(marks) { liveCost[it.point] ?: it.cost })
+    }
+
+    @Test
+    fun `totalScore live resolver falls back to the snapshot for a point absent from the legend`() {
+        val marks = listOf(mark("a", point = 9, number = 1, cost = 4, complete = true))
+        // Point 9 dropped from the legend → resolver misses → snapshot (4) is used.
+        assertEquals(4, totalScore(marks) { emptyMap<Int, Int>()[it.point] ?: it.cost })
+    }
+
+    @Test
+    fun `marksToTiles costOf resolves the live tile cost`() {
+        val tiles = marksToTiles(
+            listOf(mark("a", point = 1, number = 1, cost = 0, complete = true)),
+            costOf = { mapOf(1 to 5)[it.point] ?: it.cost },
+        )
+        assertEquals(5, tiles.single().cost)
+    }
+
+    @Test
+    fun `marksToTiles cost defaults to the snapshot without a resolver`() {
+        val tiles = marksToTiles(listOf(mark("a", point = 1, number = 1, cost = 7)))
+        assertEquals(7, tiles.single().cost)
+    }
 }


### PR DESCRIPTION
«Отметки» СУММА summed the cost snapshotted onto each mark row at scan time, while «Легенда» summed the live CheckpointEntity.cost. After an organizer edits a КП cost (e.g. 0→5), the legend resync updates the live value but the mark snapshot stays stale, so the two tabs diverge (2/11 vs 7/11).

Score Отметки СУММА and tiles off the live legend cost, joined by point id, falling back to the mark snapshot for a point dropped from the legend. The snapshot stays on the row as the anti-cheat/server-log record.