### PR TITLE
feat: auto + pull-to-refresh on Соревнование picker

### DIFF
--- a/app/src/main/java/ru/kolco24/kolco24/MainActivity.kt
+++ b/app/src/main/java/ru/kolco24/kolco24/MainActivity.kt
@@ -491,6 +491,19 @@ private fun Kolco24AppRoot(
         }
     }
 
+    // Races refresh for the comp picker (auto-on-open + pull-to-refresh). Standalone rather than the
+    // raceId-bound `pullRefresh` above: refreshRaces() takes no raceId and must work with no team
+    // selected — the exact offline-no-team state where the bug surfaced (empty list, no way to retry).
+    var racesRefreshing by remember { mutableStateOf(false) }
+    fun refreshRacesPull() {
+        racesRefreshing = true
+        scope.launch {
+            val result = raceRepo.refreshRaces()
+            racesRefreshing = false
+            refreshErrorMessage(result)?.let { snackbarHostState.showSnackbar(it) }
+        }
+    }
+
     val teamState by produceState<SelectedTeamState>(SelectedTeamState.Loading) {
         teamRepo.selectedTeam.collectLatest { selection ->
             val teamId = selection?.teamId
@@ -1177,6 +1190,8 @@ private fun Kolco24AppRoot(
                 races = races,
                 today = today,
                 selectedRaceId = selectedRaceId,
+                isRefreshing = racesRefreshing,
+                onRefresh = { refreshRacesPull() },
                 onBack = { showSettings = false; teamFlowStep = TeamFlowStep.None },
                 onRaceSelected = { raceId ->
                     // Warm Room ahead of the screen transition so the team list is ready when the

--- a/app/src/main/java/ru/kolco24/kolco24/ui/teampicker/CompPickerScreen.kt
+++ b/app/src/main/java/ru/kolco24/kolco24/ui/teampicker/CompPickerScreen.kt
@@ -28,6 +28,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.saveable.rememberSaveable
@@ -41,6 +42,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import ru.kolco24.kolco24.data.db.RaceEntity
+import ru.kolco24.kolco24.ui.common.RefreshableList
 import ru.kolco24.kolco24.ui.theme.RobotoMono
 
 /** Amber month label inside the charcoal calendar token (matches the mock's `AMBER`). */
@@ -56,6 +58,11 @@ private val MONTH_ABBR = listOf(
  * Screen 04b — race picker (step 1 of choosing a team). Shows the races from Room split into
  * current / archive tabs; tapping a row opens its team list via [onRaceSelected]. Pure UI —
  * the split and status rules live in [TeamPickerLogic] and are unit-tested there.
+ *
+ * Races are refreshed on open ([onRefresh] in a one-shot [LaunchedEffect]) and via pull-to-refresh,
+ * so a picker opened with an empty/stale cache (e.g. the app cold-started offline) self-heals once
+ * connectivity returns — without restarting the app. [refreshRaces] is no-arg and works with no team
+ * selected, so this is wired in the host directly rather than through the raceId-bound `pullRefresh`.
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -63,11 +70,17 @@ fun CompPickerScreen(
     races: List<RaceEntity>,
     today: String,
     selectedRaceId: Int?,
+    isRefreshing: Boolean,
+    onRefresh: () -> Unit,
     onBack: () -> Unit,
     onRaceSelected: (Int) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     var showArchive by rememberSaveable { mutableStateOf(false) }
+
+    // Auto-refresh once when the picker opens (the screen is composed fresh each open, behind an `if`
+    // in the host). refreshRaces() is ETag-guarded — a no-op 304 when nothing changed — so this is cheap.
+    LaunchedEffect(Unit) { onRefresh() }
 
     val split = splitRaces(races, today)
     val list = if (showArchive) split.archive else split.current
@@ -92,38 +105,40 @@ fun CompPickerScreen(
             ),
         )
 
-        LazyColumn(
-            modifier = Modifier.fillMaxSize(),
-            contentPadding = PaddingValues(bottom = 16.dp),
-        ) {
-            item("chips") {
-                Row(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(horizontal = 8.dp)
-                        .padding(top = 6.dp, bottom = 12.dp),
-                    horizontalArrangement = Arrangement.spacedBy(8.dp),
-                ) {
-                    CompFilterChip(
-                        selected = !showArchive,
-                        onClick = { showArchive = false },
-                        label = "Актуальные · ${split.current.size}",
-                    )
-                    CompFilterChip(
-                        selected = showArchive,
-                        onClick = { showArchive = true },
-                        label = "Архив · ${split.archive.size}",
+        RefreshableList(isRefreshing = isRefreshing, onRefresh = onRefresh) {
+            LazyColumn(
+                modifier = Modifier.fillMaxSize(),
+                contentPadding = PaddingValues(bottom = 16.dp),
+            ) {
+                item("chips") {
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 8.dp)
+                            .padding(top = 6.dp, bottom = 12.dp),
+                        horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    ) {
+                        CompFilterChip(
+                            selected = !showArchive,
+                            onClick = { showArchive = false },
+                            label = "Актуальные · ${split.current.size}",
+                        )
+                        CompFilterChip(
+                            selected = showArchive,
+                            onClick = { showArchive = true },
+                            label = "Архив · ${split.archive.size}",
+                        )
+                    }
+                }
+
+                item("list") {
+                    CompListCard(
+                        races = list,
+                        today = today,
+                        selectedRaceId = selectedRaceId,
+                        onRaceSelected = onRaceSelected,
                     )
                 }
-            }
-
-            item("list") {
-                CompListCard(
-                    races = list,
-                    today = today,
-                    selectedRaceId = selectedRaceId,
-                    onRaceSelected = onRaceSelected,
-                )
             }
         }
     }


### PR DESCRIPTION
The comp picker only ever got races from Room — refreshRaces() ran once at app startup. A cold start offline left the races table empty with no way to reload, so opening «Выбрать команду» showed a permanently empty list even after connectivity returned.

Add a one-shot auto-refresh on open plus pull-to-refresh (reusing the existing RefreshableList / refreshErrorMessage components). Wired with a standalone races refresher in the host since refreshRaces() is no-arg and must work with no team selected, unlike the raceId-bound pullRefresh helper.