### PR TITLE
feat: zero-cost КП show number only

### DIFF
--- a/app/src/main/java/ru/kolco24/kolco24/ui/legend/LegendScreen.kt
+++ b/app/src/main/java/ru/kolco24/kolco24/ui/legend/LegendScreen.kt
@@ -562,7 +562,11 @@ private fun OpenCheckpointRow(cp: CheckpointEntity, taken: Boolean) {
         horizontalArrangement = Arrangement.spacedBy(12.dp),
     ) {
         Text(
-            text = "${cp.cost ?: 0}-${cp.number.toString().padStart(2, '0')}",
+            text = if (cp.cost == 0) {
+                cp.number.toString().padStart(2, '0')
+            } else {
+                "${cp.cost ?: 0}-${cp.number.toString().padStart(2, '0')}"
+            },
             style = MaterialTheme.typography.bodyMedium.copy(
                 fontSize = 16.sp,
                 fontWeight = FontWeight.SemiBold,

--- a/app/src/main/java/ru/kolco24/kolco24/ui/marks/MarksScreen.kt
+++ b/app/src/main/java/ru/kolco24/kolco24/ui/marks/MarksScreen.kt
@@ -805,11 +805,17 @@ private fun NfcTileBody(mark: Mark, textColor: Color) {
 /**
  * The `<стоимость>-<номер>` token with the hyphen dimmed to 50% alpha (the digits inherit the caller's
  * text color), so the cost and number read as two values rather than one run on the color fill.
+ * A zero-cost КП (transit/test zone) shows only the bare number — no cost prefix, no hyphen.
  */
 private fun tokenAnnotated(mark: Mark, textColor: Color): AnnotatedString = buildAnnotatedString {
-    append("${mark.cost}")
-    withStyle(SpanStyle(color = textColor.copy(alpha = 0.5f))) { append("-") }
-    append(mark.number)
+    if (mark.cost == 0) {
+        // Zero-cost КП (transit/test zone): show only the number, no cost prefix.
+        append(mark.number)
+    } else {
+        append("${mark.cost}")
+        withStyle(SpanStyle(color = textColor.copy(alpha = 0.5f))) { append("-") }
+        append(mark.number)
+    }
 }
 
 /**

--- a/app/src/main/java/ru/kolco24/kolco24/ui/scan/ScanScreen.kt
+++ b/app/src/main/java/ru/kolco24/kolco24/ui/scan/ScanScreen.kt
@@ -461,9 +461,19 @@ private fun CheckpointSheetCard(session: ScanSession?) {
     }
 }
 
-/** «18 баллов» — the КП value, secondary to the numeral. The number itself wears the brand red. */
+/** «18 баллов» — the КП value, secondary to the numeral. The number itself wears the brand red.
+ *  A zero-cost КП (transit/test zone) shows «без баллов» instead of «0 баллов». */
 @Composable
 private fun CostStat(cost: Int?, modifier: Modifier = Modifier) {
+    if (cost == 0) {
+        Text(
+            text = "без баллов",
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = modifier,
+        )
+        return
+    }
     Row(modifier = modifier, verticalAlignment = Alignment.Bottom) {
         Text(
             text = cost?.toString() ?: "—",


### PR DESCRIPTION
КП with cost==0 (transit/test zones like 0-01) now display just the number, dropping the cost prefix in the legend and marks tiles, and showing «без баллов» instead of «0 баллов» on the scan screen.